### PR TITLE
Simplify string-join using a loop

### DIFF
--- a/recipes/join-list-of-strings-with-delimiter.md
+++ b/recipes/join-list-of-strings-with-delimiter.md
@@ -29,11 +29,11 @@ Credit [Jakub T. Jankiewicz](https://jcubic.pl/me)
 ### Using fold
 
 ```
-(define (string-join list delimiter)
-  (if (null? list) ""
+(define (string-join lst delimiter)
+  (if (null? lst) ""
       (fold (lambda (item result) (string-append result delimiter item))
-            (car list)
-            (cdr list))))
+            (car lst)
+            (cdr lst))))
 ```
 
 Credit [Lassi Kortela](https://github.com/lassik)
@@ -41,15 +41,15 @@ Credit [Lassi Kortela](https://github.com/lassik)
 ### Using string ports
 
 ```
-(define (string-join list delimiter)
-  (if (null? list) ""
+(define (string-join lst delimiter)
+  (if (null? lst) ""
       (call-with-port (open-output-string)
                       (lambda (out)
-                        (write-string (car list) out)
+                        (write-string (car lst) out)
                         (for-each (lambda (item)
                                     (write-string delimiter out)
                                     (write-string item out))
-                                  (cdr list))
+                                  (cdr lst))
                         (get-output-string out)))))
 ```
 

--- a/recipes/join-list-of-strings-with-delimiter.md
+++ b/recipes/join-list-of-strings-with-delimiter.md
@@ -13,15 +13,13 @@ SRFI 13 provides the [`string-join` procedure](https://srfi.schemers.org/srfi-13
 ### Using a loop
 
 ```
-(define (string-join list delimiter)
-  (let iter ((list list) (result '()))
-    (if (null? list)
-        (apply string-append (reverse result))
-        (let ((item (car list))
-              (rest (cdr list)))
-          (if (null? result)
-              (iter rest (cons item result))
-              (iter rest (cons item (cons delimiter result))))))))
+(define (string-join lst delimiter)
+  (if (null? lst) ""
+      (let loop ((result (car lst)) (lst (cdr lst)))
+        (if (null? lst)
+            result
+            (loop (string-append result delimiter (car lst))
+                  (cdr lst))))))
 ```
 
 Credit [Jakub T. Jankiewicz](https://jcubic.pl/me)


### PR DESCRIPTION
- The `(if (null? result) ...)` check can be done once, before the loop. It doesn't need to be done separately on each iteration.

- Carrying the result as a string, and using `string-append` on each iteration, is probably more efficient than gathering the strings into a temporary list. Avoiding `apply` will also avoid implementation limits on how many args can be passed to a procedure (if `lst` is very long, it can exceed the limit).

- Use the names `lst` and `loop` as decided in #16.