### PR TITLE
Refactor find-substring example

### DIFF
--- a/recipes/create-k-combinations-from-list.md
+++ b/recipes/create-k-combinations-from-list.md
@@ -47,6 +47,7 @@ Credit: [Nils M Holm](https://t3x.org/) (ref: [combine.scm](https://t3x.org/s9fe
 ```scheme
 (combine 2 '(a b c))
 ;; ==> ((a b) (a c) (b c))
+
 (combine* 2 '(a b c))
 ;; ==>  ((a a) (a b) (a c) (b b) (b c) (c c))
 ```

--- a/recipes/find-substring-in-string.md
+++ b/recipes/find-substring-in-string.md
@@ -37,9 +37,6 @@ The same functionality is provided by SRFI-13 function `string-contains` and `st
 (let* ((input "This is hello world")
        (search "hello")
        (found (string-find input search)))
-  (if found
-      (begin
-        (display (substring input found))
-        (newline))))
+    (and found (substring input found (string-length input))))
 ;; ==> "hello world"
 ```

--- a/recipes/index-list.md
+++ b/recipes/index-list.md
@@ -35,6 +35,5 @@ Credit: [Arthur A. Gleckler](https://speechcode.com/)
              (make-eq-hash-table)
              (lambda (a) (list (car a)))
              cdr))
-
 ;; ==> ((bar bat foo) (baz quux))
 ```

--- a/recipes/split-list-into-groups-by-comparator.md
+++ b/recipes/split-list-into-groups-by-comparator.md
@@ -33,6 +33,7 @@ Credit: [Nils M Holm](https://t3x.org/) (ref: [collect.scm](https://t3x.org/s9fe
 ```scheme
 (collect eq? '(a a a b c c))
 ;; ==> ((a a a) (b) (c c))
+
 (collect < '(1 2 3 3 4 5 4))
 ;; ==> ((1 2 3) (3 4 5) (4))
 ```

--- a/recipes/use-list-as-set.md
+++ b/recipes/use-list-as-set.md
@@ -20,6 +20,7 @@ Credit: [Nils M Holm](https://t3x.org/) (ref: [adjoin.scm](https://t3x.org/s9fes
 ```scheme
 (adjoin 'x '(a b c))
 ;; ==> (x a b c)
+
 (adjoin 'c '(a b c))
 ;; ==> (a b c)
 ```


### PR DESCRIPTION
Returning the string instead of using `display` will produce the indicated `"hello world"` (with quotes) in a Scheme REPL.