### PR TITLE
recipe: type function

### DIFF
--- a/recipes/get-type-of-object.md
+++ b/recipes/get-type-of-object.md
@@ -7,34 +7,43 @@ You need a procedure that will return the type of the object as a string.
 ## Solution
 
 ```Scheme
-(define (type obj)
-  (cond ((number? obj) "number")
-        ((pair? obj) "pair")
-        ((null? obj) "nil")
-        ((string? obj) "string")
-        ((symbol? obj) "symbol")
-        ((vector? obj) "vector")
-        ((procedure? obj) "procedure")
-        ((port? obj)
-         (cond ((input-port? obj) "input-port")
-               ((output-port? obj) "output-port")
-               (else "unknown-port")))
-        ((eof-object? obj) "eof")
-        ((char? obj) "character")
-        ((boolean? obj) "boolean")))
+(cond-expand
+ (r7rs
+  (define type-of-alist-extra (list (cons bytevector? 'bytevector))))
+ (else
+  (define type-of-alist-extra '())))
+
+(define type-of-alist
+  (append type-of-alist-extra
+          (list (cons boolean?    'boolean)
+                (cons char?       'character)
+                (cons eof-object? 'eof-object)
+                (cons null?       'null)
+                (cons number?     'number)
+                (cons pair?       'pair)
+                (cons port?       'port)
+                (cons procedure?  'procedure)
+                (cons string?     'string)
+                (cons symbol?     'symbol)
+                (cons vector?     'vector))))
+
+(define (type-of obj)
+  (let loop ((alist type-of-alist))
+    (and (not (null? alist))
+         (if ((caar alist) obj) (cdar alist) (loop (cdr alist))))))
 ```
 
-Credit: [Jakub T. Jankiewicz](https://jcubic.pl/me)
+Credit: [Lassi Kortela](https://github.com/lassik)
 
 ## Usage
 
 ```Scheme
-(type "foo")
-;; ==> "string"
+(type-of "foo")
+;; ==> string
 
-(type #\x)
-;; ==> "character"
+(type-of #\x)
+;; ==> character
 
-(type (current-input-port))
-;; ==> "input-port"
+(type-of (current-input-port))
+;; ==> input-port
 ```

--- a/recipes/get-type-of-object.md
+++ b/recipes/get-type-of-object.md
@@ -1,0 +1,40 @@
+# Get type of object
+
+## Problem
+
+You need a procedure that will return the type of the object as a string.
+
+## Solution
+
+```Scheme
+(define (type obj)
+  (cond ((number? obj) "number")
+        ((pair? obj) "pair")
+        ((null? obj) "nil")
+        ((string? obj) "string")
+        ((symbol? obj) "symbol")
+        ((vector? obj) "vector")
+        ((procedure? obj) "procedure")
+        ((port? obj)
+         (cond ((input-port? obj) "input-port")
+               ((output-port? obj) "output-port")
+               (else "unknown-port")))
+        ((eof-object? obj) "eof")
+        ((char? obj) "character")
+        ((boolean? obj) "boolean")))
+```
+
+Credit: [Jakub T. Jankiewicz](https://jcubic.pl/me)
+
+## Usage
+
+```Scheme
+(type "foo")
+;; ==> "string"
+
+(type #\x)
+;; ==> "character"
+
+(type (current-input-port))
+;; ==> "input-port"
+```

--- a/www-index.scm
+++ b/www-index.scm
@@ -30,6 +30,7 @@
   "join-list-of-strings-with-delimiter"
   "remove-whitespace-from-string"
   "find-substring-in-string"
+  "get-type-of-object"
   "split-string")
 
  ("Numbers"


### PR DESCRIPTION
New recipe. There is a missing `bytevector?`, but it was not working in Chicken and Guile out of the box.