### PR TITLE
exists => find-stride

### DIFF
--- a/recipes/nondeterminism-using-amb.md
+++ b/recipes/nondeterminism-using-amb.md
@@ -54,7 +54,7 @@ It also depends on two other recipes:
 (define (amb-collector)
   (let ((values '()))
     (lambda (p . v*)
-      (if (exists amb-done? v*)
+      (if (find-stride amb-done? v*)
           values
           (begin
             (if (apply p v*)


### PR DESCRIPTION
The name of the procedure was renamed so the code was not working.